### PR TITLE
Fix pio build on rpi

### DIFF
--- a/stm32/ros_usbnode/platformio.ini
+++ b/stm32/ros_usbnode/platformio.ini
@@ -20,3 +20,6 @@ platform = ststm32
 board = genericSTM32F103VC
 framework = stm32cube
 build_flags = -DBOARD_YARDFORCE500 -Wl,--undefined,_printf_float -Isrc/ros/ros_lib -Isrc/ros/ros_custom 
+; Required to build on RPI https://community.platformio.org/t/toolchain-gccarmnoneeabi-for-aarch64/15973/10
+platform_packages =
+   toolchain-gccarmnoneeabi@~1.90301.0


### PR DESCRIPTION
The default GCC 7.2.1 package is not available, use 9.3.1 (from
https://community.platformio.org/t/toolchain-gccarmnoneeabi-for-aarch64/15973/10)