### PR TITLE
Improve charging logic when battery is powering rpi

### DIFF
--- a/stm32/ros_usbnode/include/board.h
+++ b/stm32/ros_usbnode/include/board.h
@@ -23,6 +23,13 @@ extern "C" {
     #define PANEL_TYPE_YARDFORCE_500_CLASSIC    1
     // #define PANEL_TYPE_YARDFORCE_900_ECO   1
 
+    // if voltage is greater than this assume we are docked
+    #define MIN_CHARGE_VOLTAGE 5.0
+    // must provide at least MIN_CHARGE_VOLTAGE when docked
+    #define MIN_CHARGE_PWM 500
+    // if current is greater than this assume the battery is charging
+    #define MIN_CHARGE_CURRENT 0.2
+
     #define LOW_BAT_THRESHOLD   23.5
 
     // we use J18 (Red 9 pin connector as Master Serial Port)

--- a/stm32/ros_usbnode/include/main.h
+++ b/stm32/ros_usbnode/include/main.h
@@ -59,6 +59,9 @@ void setBladeMotor(uint8_t on_off);
 uint8_t crcCalc(uint8_t *msg, uint8_t msg_len);
 void msgPrint(uint8_t *msg, uint8_t msg_len);
 
+extern float battery_voltage;
+extern float charge_voltage;
+extern float charge_current;
 
 extern uint16_t chargecontrol_pwm_val;
 extern uint8_t  chargecontrol_is_charging;

--- a/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
+++ b/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
@@ -100,6 +100,7 @@ double theta = 1.57;
 // std_msgs::String str_msg;
 std_msgs::Float32 f32_battery_voltage_msg;
 std_msgs::Float32 f32_charge_voltage_msg;
+std_msgs::Float32 f32_charge_current_msg;
 std_msgs::Int16 int16_charge_pwm_msg;
 std_msgs::Bool bool_blade_state_msg;
 std_msgs::Bool bool_charging_state_msg;
@@ -119,6 +120,7 @@ sensor_msgs::MagneticField imu_mag_calibration_msg;
 // ros::Publisher chatter("version", &str_msg);
 ros::Publisher pubBatteryVoltage("battery_voltage", &f32_battery_voltage_msg);
 ros::Publisher pubChargeVoltage("charge_voltage", &f32_charge_voltage_msg);
+ros::Publisher pubChargeCurrent("charge_current", &f32_charge_current_msg);
 ros::Publisher pubChargePWM("charge_pwm", &int16_charge_pwm_msg);
 ros::Publisher pubChargeingState("charging_state", &bool_charging_state_msg);
 ros::Publisher pubBladeState("blade_state", &bool_blade_state_msg);
@@ -248,11 +250,14 @@ extern "C" void chatter_handler()
 		  chatter.publish(&str_msg);
 		  */
 		  
-		  f32_battery_voltage_msg.data = ADC_BatteryVoltage();
+		  f32_battery_voltage_msg.data = battery_voltage;
 		  pubBatteryVoltage.publish(&f32_battery_voltage_msg);
 
-		  f32_charge_voltage_msg.data = ADC_ChargeVoltage();
+		  f32_charge_voltage_msg.data = charge_voltage;
 		  pubChargeVoltage.publish(&f32_charge_voltage_msg);
+
+		  f32_charge_current_msg.data = charge_current;
+		  pubChargeCurrent.publish(&f32_charge_current_msg);
 
 		  int16_charge_pwm_msg.data = chargecontrol_pwm_val;
 		  pubChargePWM.publish(&int16_charge_pwm_msg);
@@ -493,6 +498,7 @@ extern "C" void init_ROS()
 	// Initialize Pubs
 	nh.advertise(pubBatteryVoltage);
 	nh.advertise(pubChargeVoltage);
+	nh.advertise(pubChargeCurrent);
 	nh.advertise(pubChargePWM);
 	nh.advertise(pubOdom);
 	nh.advertise(pubBladeState);


### PR DESCRIPTION
My battery never reaches 29.4V while powering the rpi. Use the charge
current instead to determine when charging is complete.