### PR TITLE
Add emergency sensor handling

### DIFF
--- a/stm32/ros_usbnode/include/board.h
+++ b/stm32/ros_usbnode/include/board.h
@@ -32,6 +32,12 @@ extern "C" {
 
     #define LOW_BAT_THRESHOLD   23.5
 
+    #define WHEEL_LIFT_EMERGENCY_MILLIS 500
+    #define TILT_EMERGENCY_MILLIS 500
+    #define STOP_BUTTON_EMERGENCY_MILLIS 20
+    #define PLAY_BUTTON_CLEAR_EMERGENCY_MILLIS 2000
+
+
     // we use J18 (Red 9 pin connector as Master Serial Port)
     #define MASTER_J18 1
 
@@ -67,7 +73,31 @@ extern "C" {
     #define CHARGE_HIGHSIDE_PIN GPIO_PIN_9
     #define CHARGE_GPIO_PORT GPIOE
     #define CHARGE_GPIO_CLK_ENABLE() __HAL_RCC_GPIOE_CLK_ENABLE();
-    
+
+    /* Stop button - (HIGH when pressed) */
+    #define STOP_BUTTON_YELLOW_PIN GPIO_PIN_0
+    #define STOP_BUTTON_YELLOW_PORT GPIOC
+    #define STOP_BUTTON_GPIO_CLK_ENABLE() __HAL_RCC_GPIOC_CLK_ENABLE()
+    #define STOP_BUTTON_WHITE_PIN GPIO_PIN_8
+    #define STOP_BUTTON_WHITE_PORT GPIOC
+
+    /* Mechanical tilt - (HIGH when set) */
+    #define TILT_PIN GPIO_PIN_8
+    #define TILT_PORT GPIOA
+    #define TILT_GPIO_CLK_ENABLE() __HAL_RCC_GPIOA_CLK_ENABLE()
+
+    /* Wheel lift - (HIGH when set) */
+    #define WHEEL_LIFT_BLUE_PIN GPIO_PIN_0
+    #define WHEEL_LIFT_BLUE_PORT GPIOD
+    #define WHEEL_LIFT_GPIO_CLK_ENABLE() __HAL_RCC_GPIOD_CLK_ENABLE()
+    #define WHEEL_LIFT_RED_PIN GPIO_PIN_1
+    #define WHEEL_LIFT_RED_PORT GPIOD
+
+    /* Play button - (LOW when pressed) */
+    #define PLAY_BUTTON_PIN GPIO_PIN_7
+    #define PLAY_BUTTON_PORT GPIOC
+    #define PLAY_BUTTON_GPIO_CLK_ENABLE() __HAL_RCC_GPIOC_CLK_ENABLE()
+
     /* either J6 or J18 can be the master USART port */
 #ifdef MASTER_J6    
     /* USART1 (J6 Pin 1 (TX) Pin 2 (RX)) */    

--- a/stm32/ros_usbnode/include/main.h
+++ b/stm32/ros_usbnode/include/main.h
@@ -53,6 +53,7 @@ float ADC_BatteryVoltage();
 float ADC_ChargeVoltage();
 float ADC_ChargeCurrent();
 void ChargeController(void);
+void EmergencyController(void);
 void StatusLEDUpdate(void);
 void setDriveMotors(uint8_t left_speed, uint8_t right_speed, uint8_t left_dir, uint8_t right_dir);
 void setBladeMotor(uint8_t on_off);
@@ -70,6 +71,7 @@ extern int16_t  right_wheel_speed_val;
 extern int16_t  left_wheel_speed_val;
 extern uint32_t right_encoder_ticks;
 extern uint32_t left_encoder_ticks;
+extern uint8_t emergency_state;
 
 // uart statistics
 extern uint16_t cnt_uart4_overrun;      // master
@@ -96,6 +98,7 @@ void ADC1_Init(void);
 void TIM1_Init(void);
 void TIM3_Init(void);
 void MX_DMA_Init(void);
+void Emergency_Init(void);
 
 
 // UART Wrapper functions to hide HAL bullshit ...


### PR DESCRIPTION
Use similar logic to OpenMower for emergency sensor handling.
Use lifted LED to signal low level emergency.
Hold play button to reset.

Also stop motors when cmd_vel messages are not being received, similar
to OpenMower logic.